### PR TITLE
Link to Doc page from terminal

### DIFF
--- a/src/Documentation/doc/index.md
+++ b/src/Documentation/doc/index.md
@@ -51,6 +51,6 @@
 
 ## Migration
 
-- [v1.0.0 script migration guide](migrations/v1.md)
-- [v2.0.0 script migration guide](migrations/v2.md)
-- [Netscript 2 migration guide](migrations/ns2.md)
+- [Bitburner v1.0.0 script migration guide](migrations/v1.md)
+- [Bitburner v2.0.0 script migration guide](migrations/v2.md)
+- [Netscript 2 migration guide (.script to .js)](migrations/ns2.md)

--- a/src/Documentation/doc/migrations/ns2.md
+++ b/src/Documentation/doc/migrations/ns2.md
@@ -3,13 +3,16 @@
 With the deprecation of NS1 (`.script`) there are required changes to migrate scripts over to NS2 (`.js`).
 
 ## Basic Steps
+
 1. You need to wrap the entire script inside of an exported main function, like so:
+
 ```js
 /** @param {NS} ns */
 export async function main(ns) {
   // your code here
 }
 ```
+
 2. Add `ns.` as a prefix to all game functions (such as `ns.hack()` or `ns.nuke()`).
 3. If a function returns a `Promise`, you need to put the `await` keyword before it (With the JSDoc comment you can hover over the function to see the return type).
 4. Long-running loops (like `while(true)`) need to `await` a function (usually `ns.sleep()`) at least once or they will crash the game.
@@ -17,12 +20,13 @@ export async function main(ns) {
 ## A demonstration of migration
 
 Original (`early-hacking-template.script`):
+
 ```js
 var target = "n00dles";
 var moneyThresh = getServerMaxMoney(target) * 0.9;
 var securityThresh = getServerMinSecurityLevel(target) + 5;
 
-while(true) {
+while (true) {
   if (getServerSecurityLevel(target) > securityThresh) {
     weaken(target);
   } else if (getServerMoneyAvailable(target) < moneyThresh) {
@@ -32,7 +36,9 @@ while(true) {
   }
 }
 ```
+
 Migrated (`early-hacking-template.js`):
+
 ```js
 /** @param {NS} ns */
 export async function main(ns) {

--- a/src/Documentation/pages.ts
+++ b/src/Documentation/pages.ts
@@ -40,7 +40,7 @@ import file37 from "!!raw-loader!./doc/programming/go_algorithms.md";
 import file38 from "!!raw-loader!./doc/programming/hackingalgorithms.md";
 import file39 from "!!raw-loader!./doc/programming/learn.md";
 import file40 from "!!raw-loader!./doc/programming/remote_api.md";
-import file41 from "!!raw-loader!./doc/migrations/ns2.md"
+import file41 from "!!raw-loader!./doc/migrations/ns2.md";
 
 interface Document {
   default: string;

--- a/src/Documentation/ui/DocumentationRoot.tsx
+++ b/src/Documentation/ui/DocumentationRoot.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import Button from "@mui/material/Button";
 import { MD } from "../../ui/MD/MD";
@@ -6,10 +6,15 @@ import { MD } from "../../ui/MD/MD";
 import { getPage } from "../root";
 import { Navigator, useHistory } from "../../ui/React/Documentation";
 import { CONSTANTS } from "../../Constants";
-import { resolveFilePath } from "../../Paths/FilePath";
+import { asFilePath, resolveFilePath } from "../../Paths/FilePath";
 
-export function DocumentationRoot(): React.ReactElement {
+export function DocumentationRoot({ docPage }: { docPage?: string }): React.ReactElement {
   const history = useHistory();
+  const [deepLink, setDeepLink] = useState(docPage);
+  if (deepLink !== undefined) {
+    history.push(asFilePath(deepLink));
+    setDeepLink(undefined);
+  }
   const page = getPage(history.page);
   const navigator = {
     navigate(relPath: string, external: boolean) {

--- a/src/Go/ui/GoInstructionsPage.tsx
+++ b/src/Go/ui/GoInstructionsPage.tsx
@@ -205,7 +205,10 @@ export const GoInstructionsPage = (): React.ReactElement => {
             <Typography>
               * You can place routers and look at the board state via the "ns.go" api. For more details, go to the IPvGO
               page in the{" "}
-              <Link style={{ cursor: "pointer" }} onClick={() => Router.toPage(Page.Documentation)}>
+              <Link
+                style={{ cursor: "pointer" }}
+                onClick={() => Router.toPage(Page.Documentation, { docPage: "programming/go_algorithms.md" })}
+              >
                 Bitburner Documentation
               </Link>
               <br />

--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -166,7 +166,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
     (page: Page) => {
       if (page === Page.Job) {
         Router.toPage(page, { location: Locations[Object.keys(Player.jobs)[0]] });
-      } else if (page == Page.ScriptEditor) {
+      } else if (page == Page.ScriptEditor || page == Page.Documentation) {
         Router.toPage(page, {});
       } else if (isSimplePage(page)) {
         Router.toPage(page);

--- a/src/Terminal/commands/common/deprecation.ts
+++ b/src/Terminal/commands/common/deprecation.ts
@@ -1,8 +1,0 @@
-import { Terminal } from "../../../Terminal";
-
-export function sendDeprecationNotice() {
-  return Terminal.warn(
-    "NOTICE: NS1 (.script) scripts are deprecated and will be removed in a future update." +
-    " Migrate to NS2 (.js) scripts instead."
-  );
-}

--- a/src/Terminal/commands/common/deprecation.tsx
+++ b/src/Terminal/commands/common/deprecation.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { Terminal } from "../../../Terminal";
+import { Settings } from "../../../Settings/Settings";
+import { Link, Typography } from "@mui/material";
+import { Router } from "../../../ui/GameRoot";
+import { Page } from "../../../ui/Router";
+
+export function sendDeprecationNotice() {
+  return Terminal.printRaw(
+    <Typography sx={{ color: Settings.theme.warning }}>
+      NOTICE: NS1 (.script) scripts are deprecated and will be removed in a future update.{" "}
+      <Link
+        style={{ cursor: "pointer" }}
+        color="inherit"
+        onClick={() => Router.toPage(Page.Documentation, { docPage: "migrations/ns2.md" })}
+      >
+        Here are instructions
+      </Link>{" "}
+      to migrate to NS2 (.js) scripts.
+    </Typography>,
+  );
+}

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -280,7 +280,7 @@ export function GameRoot(): React.ReactElement {
       break;
     }
     case Page.Documentation: {
-      mainPage = <DocumentationRoot />;
+      mainPage = <DocumentationRoot docPage={pageWithContext.docPage} />;
       break;
     }
     case Page.DevMenu: {

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -29,7 +29,6 @@ export enum SimplePage {
   StockMarket = "Stock Market",
   Terminal = "Terminal",
   Travel = "Travel",
-  Documentation = "Documentation",
   Work = "Work",
   BladeburnerCinematic = "Bladeburner Cinematic",
   Loading = "Loading",
@@ -48,6 +47,7 @@ export enum ComplexPage {
   ScriptEditor = "Script Editor",
   Location = "Location",
   ImportSave = "Import Save",
+  Documentation = "Documentation",
 }
 
 // Using the same name as both type and object to mimic enum-like behavior.
@@ -71,6 +71,8 @@ export type PageContext<T extends Page> = T extends ComplexPage.BitVerse
   ? { location: Location }
   : T extends ComplexPage.ImportSave
   ? { base64Save: string; automatic?: boolean }
+  : T extends ComplexPage.Documentation
+  ? { docPage?: string }
   : never;
 
 export type PageWithContext =
@@ -82,6 +84,7 @@ export type PageWithContext =
   | ({ page: ComplexPage.ScriptEditor } & PageContext<ComplexPage.ScriptEditor>)
   | ({ page: ComplexPage.Location } & PageContext<ComplexPage.Location>)
   | ({ page: ComplexPage.ImportSave } & PageContext<ComplexPage.ImportSave>)
+  | ({ page: ComplexPage.Documentation } & PageContext<ComplexPage.Documentation>)
   | { page: SimplePage };
 
 export interface ScriptEditorRouteOptions {


### PR DESCRIPTION
Added support for deep links to documentation pages in `Router.toPage()`, and made use of this in the `sendDeprecationNotice()` function.